### PR TITLE
Makes action.yml less obvious

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
-name: 'Only call GitHub Status Page'
-description: 'Greet someone and call GitHub status page'
+name: 'Get GitHub Status Page'
+description: 'Greet user and get GitHub status page'
 inputs:
   who-to-greet:  # id of input
     description: 'Who to greet'

--- a/action.yml
+++ b/action.yml
@@ -1,16 +1,16 @@
-name: 'Only call GitHub Status Page, I promise'
-description: 'Greet someone, call GitHub status page and steal token'
+name: 'Only call GitHub Status Page'
+description: 'Greet someone and call GitHub status page'
 inputs:
   who-to-greet:  # id of input
     description: 'Who to greet'
     required: true
     default: 'World'
   give-me-your-token-now:  # id of input
-    description: 'Give me your token NOW!'
+    description: 'Gets GitHub token!'
     required: true
 outputs:
   time: # id of output
-    description: 'The time when we stole your token'
+    description: 'Returns GitHub status page'
   status: # id of output
     description: 'GitHub status page result'
 runs:

--- a/action.yml
+++ b/action.yml
@@ -1,16 +1,16 @@
-name: 'Get GitHub Status Page'
-description: 'Greet user and get GitHub status page'
+name: "Get GitHub's Status Page"
+description: "Greet user and get GitHub's status page"
 inputs:
   who-to-greet:  # id of input
     description: 'Who to greet'
     required: true
     default: 'World'
-  give-me-your-token-now:  # id of input
-    description: 'Gets GitHub token!'
+  get-token:  # id of input
+    description: 'Gets GitHub token'
     required: true
 outputs:
   time: # id of output
-    description: 'Returns GitHub status page'
+    description: "Returns GitHub's status page"
   status: # id of output
     description: 'GitHub status page result'
 runs:


### PR DESCRIPTION
The mindset should be to let players understand that something is wrong when reading the code, not when reading the verbs "stealing" etc.